### PR TITLE
Add tests for Project API

### DIFF
--- a/tests/integration/api_project_board_test.go
+++ b/tests/integration/api_project_board_test.go
@@ -5,23 +5,155 @@
 package integration
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/tests"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIListProjectBoads(t *testing.T) {
+func TestAPIListProjectBoards(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	project := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards", project.ID))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+
+	var apiBoards []*api.ProjectBoard
+	req := NewRequest(t, "GET", link.String())
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	DecodeJSON(t, resp, &apiBoards)
+	assert.Len(t, apiBoards, 3)
 }
 
 func TestAPICreateProjectBoard(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	project := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards", project.ID))
+	link.RawQuery = url.Values{"token": {token}}.Encode()
+
+	payload := &api.NewProjectBoardPayload{
+		Title:   "Test Board",
+		Color:   "#000000",
+		Default: false,
+	}
+
+	req := NewRequestWithJSON(t, "POST", link.String(), payload)
+	resp := session.MakeRequest(t, req, http.StatusCreated)
+	var apiBoard *api.ProjectBoard
+	DecodeJSON(t, resp, &apiBoard)
+	assert.Equal(t, payload.Title, apiBoard.Title)
+	assert.Equal(t, payload.Color, apiBoard.Color)
+	assert.Equal(t, payload.Default, apiBoard.Default)
 }
 
 func TestAPIGetProjectBoard(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	project := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	testCase := []struct {
+		boardID       int64
+		expectedBoard *api.ProjectBoard
+	}{
+		{1, &api.ProjectBoard{Title: "Test Board 1", Color: "#000000", Default: true}},
+		{2, &api.ProjectBoard{Title: "Test Board 2", Color: "#000000", Default: false}},
+		{3, &api.ProjectBoard{Title: "Test Board 3", Color: "#000000", Default: false}},
+	}
+
+	for _, test := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards/%d", project.ID, test.boardID))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequest(t, "GET", link.String())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		var apiBoard *api.ProjectBoard
+		DecodeJSON(t, resp, apiBoard)
+		assert.Equal(t, test.expectedBoard.Title, apiBoard.Title)
+		assert.Equal(t, test.expectedBoard.Color, apiBoard.Color)
+		assert.Equal(t, test.expectedBoard.Default, apiBoard.Default)
+	}
 }
 
 func TestAPIGetProjectBoardReqPermission(t *testing.T) {
 }
 
 func TestAPIUpdateProjectBoard(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	project := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	payload := &api.UpdateProjectBoardPayload{
+		Title: "Edit Test Board",
+		Color: "#000000",
+	}
+
+	expected := &api.ProjectBoard{
+		Title: payload.Title,
+		Color: payload.Color,
+	}
+
+	testCase := []int{1, 2, 3}
+	for _, boardID := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards/%d", project.ID, boardID))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequestWithJSON(t, "PATCH", link.String(), payload)
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		var apiBoard *api.ProjectBoard
+		DecodeJSON(t, resp, apiBoard)
+		assert.Equal(t, expected.Title, apiBoard.Title)
+		assert.Equal(t, expected.Color, apiBoard.Color)
+		assert.Equal(t, expected.Default, apiBoard.Default)
+	}
 }
 
 func TestAPIDeleteProjectBoard(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	project := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session)
+
+	testCase := []int{1, 2, 3}
+	for _, boardID := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards/%d", project.ID, boardID))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequest(t, "DELETE", link.String())
+		resp := session.MakeRequest(t, req, http.StatusNoContent)
+		DecodeJSON(t, resp, nil)
+
+		// Check if board is deleted
+		link, _ = url.Parse(fmt.Sprintf("/api/v1/projects/%d/boards/%d", project.ID, boardID))
+		req = NewRequest(t, "GET", link.String())
+		resp = session.MakeRequest(t, req, http.StatusNotFound)
+	}
 }

--- a/tests/integration/api_project_test.go
+++ b/tests/integration/api_project_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	auth_model "code.gitea.io/gitea/models/auth"
+	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	api "code.gitea.io/gitea/modules/structs"
@@ -18,46 +19,142 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIListUserProjects(t *testing.T) {
-}
-
-func TestAPIListOrgProjects(t *testing.T) {
+func TestAPIListProjects(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 17})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
 	session := loginUser(t, user.Name)
-	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadOrganization, auth_model.AccessTokenScopeReadIssue)
-	link, _ := url.Parse(fmt.Sprintf("/api/v1/orgs/%s/projects", org.Name))
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadUser, auth_model.AccessTokenScopeReadOrganization, auth_model.AccessTokenScopeReadRepository, auth_model.AccessTokenScopeReadIssue)
 
-	link.RawQuery = url.Values{"token": { token}}.Encode()
+	testCase := []struct {
+		link        string
+		expectedLen int
+	}{
+		{fmt.Sprintf("/api/v1/user/%s/projects", user.Name), 1},
+		{fmt.Sprintf("/api/v1/orgs/%s/projects", org.Name), 1},
+		{fmt.Sprintf("/api/v1/repos/%s/%s/projects", user.Name, repo.Name), 1},
+	}
 
-	req := NewRequest(t, "GET", link.String())
-	var apiProjects []*api.Project
+	for _, test := range testCase {
+		link, _ := url.Parse(test.link)
+		link.RawQuery = url.Values{"token": {token}}.Encode()
 
-	resp := session.MakeRequest(t, req, http.StatusOK)
-	DecodeJSON(t, resp, &apiProjects)
-	assert.Len(t, apiProjects, 1)
-
+		var apiProjects []*api.Project
+		req := NewRequest(t, "GET", link.String())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		DecodeJSON(t, resp, &apiProjects)
+		assert.Len(t, apiProjects, test.expectedLen)
+	}
 }
 
-func TestAPIListRepoProjects(t *testing.T) {
-}
+func TestAPICreateProject(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
 
-func TestAPICreateUserProject(t *testing.T) {
-}
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 17})
 
-func TestAPICreateOrgProject(t *testing.T) {
-}
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteUser, auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteIssue)
 
-func TestAPICreateRepoProject(t *testing.T) {
+	payload := api.NewProjectPayload{
+		Title:       "Test Project",
+		Description: "Test Project Description",
+		BoardType:   uint8(1),
+	}
+
+	expectedProject := api.Project{
+		Title:       "Test Project",
+		Description: "Test Project Description",
+		BoardType:   uint8(1),
+	}
+
+	testCase := []struct {
+		link string
+	}{
+		{fmt.Sprintf("/api/v1/user/%s/projects", user.Name)},
+		{fmt.Sprintf("/api/v1/repos/%s/%s/projects", user.Name, repo.Name)},
+		{fmt.Sprintf("/api/v1/orgs/%s/projects", org.Name)},
+	}
+
+	for _, test := range testCase {
+		link, _ := url.Parse(test.link)
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequestWithJSON(t, "POST", link.String(), payload)
+		resp := session.MakeRequest(t, req, http.StatusCreated)
+
+		var apiProject api.Project
+		DecodeJSON(t, resp, &apiProject)
+		assert.Equal(t, expectedProject.Title, apiProject.Title)
+		assert.Equal(t, expectedProject.Description, apiProject.Description)
+		assert.Equal(t, expectedProject.BoardType, apiProject.BoardType)
+	}
 }
 
 func TestAPIGetProject(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadUser, auth_model.AccessTokenScopeReadRepository, auth_model.AccessTokenScopeReadIssue)
+
+	testCase := []struct {
+		projectID       int
+		expectedProject api.Project
+	}{
+		{1, api.Project{ID: 1, Title: "First project"}},
+		{2, api.Project{ID: 2, Title: "Second project"}},
+	}
+
+	for _, test := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d", test.projectID))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequest(t, "GET", link.String())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+
+		var apiProject api.Project
+		DecodeJSON(t, resp, &apiProject)
+		assert.Equal(t, test.expectedProject.ID, apiProject.ID)
+		assert.Equal(t, test.expectedProject.Title, apiProject.Title)
+	}
 }
 
 func TestAPIUpdateProject(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteUser, auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteIssue)
+
+	payload := api.UpdateProjectPayload{
+		Title:       "Edited test Project",
+		Description: "Edited test Project Description",
+	}
+
+	expectedProject := api.Project{
+		Title:       "Edited test Project",
+		Description: "Edited test Project Description",
+	}
+
+	testCase := []int{1, 2}
+
+	for _, test := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d", test))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequestWithJSON(t, "PATCH", link.String(), payload)
+		resp := session.MakeRequest(t, req, http.StatusOK)
+
+		var apiProject api.Project
+		DecodeJSON(t, resp, &apiProject)
+		assert.Equal(t, expectedProject.Title, apiProject.Title)
+		assert.Equal(t, expectedProject.Description, apiProject.Description)
+	}
 }
 
 func TestAPIDeleteProject(t *testing.T) {

--- a/tests/integration/api_project_test.go
+++ b/tests/integration/api_project_test.go
@@ -158,4 +158,23 @@ func TestAPIUpdateProject(t *testing.T) {
 }
 
 func TestAPIDeleteProject(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteUser, auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteIssue)
+
+	testCase := []int{1, 2}
+
+	for _, test := range testCase {
+		link, _ := url.Parse(fmt.Sprintf("/api/v1/projects/%d", test))
+		link.RawQuery = url.Values{"token": {token}}.Encode()
+
+		req := NewRequest(t, "DELETE", link.String())
+		session.MakeRequest(t, req, http.StatusNoContent)
+
+		link, _ = url.Parse(fmt.Sprintf("/api/v1/projects/%d", test))
+		req = NewRequest(t, "GET", link.String())
+		session.MakeRequest(t, req, http.StatusNotFound)
+	}
 }


### PR DESCRIPTION
As title. 
I think some APIs are still not perfect so the tests are still very basic.
1.  should `UpdateProjectPayload` and `NewProjectPayload` be separated? I just find those are pretty similar.
2. `CardType` is not used?
3. `TestAPIGetProjectBoardReqPermission` I can't quite understand this test so I didn't add it.

Thanks for your marvelous work for that PR! Really hope that PR can merged before 1.22. If you want any help from me or other maintainers, feel free to ask!